### PR TITLE
Add tips for testing with ES Modules

### DIFF
--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -13,7 +13,7 @@ Tests here are kept next to their code (not in a separate dir). This was done to
 ## ES Modules
 
 If your typescript project's `tsconfig.json` has module code generation set to something other than `CommonJS`, you may
-encounter an error "SyntaxError: Unexpected token {" when you use an import statement.
+encounter an error `"SyntaxError: Unexpected token {"` when you use an import statement.
 
 ```
 import { fail, ok } from 'assert';
@@ -24,7 +24,7 @@ SyntaxError: Unexpected token {
 
 ```
 
-This is because the underlying ts-node does not support ES modules:
+This is because the underlying `ts-node` does not support ES modules:
 
 
  > Import Statements
@@ -32,8 +32,9 @@ This is because the underlying ts-node does not support ES modules:
 
 See: https://www.npmjs.com/package/ts-node#import-statements
 
-A workaround is to change the `compilerOptions` that `ts-node` sees when `mocha` is executed. The environment variable
-`TS_NODE_COMPILER_OPTIONS` can be set when executing `mocha` to give `ts-code` a module setting of `commonjs`. In `package.json`:
+You may need `tsconfig.json` compiler options for `module` to be something other than `commonjs`. You can still set it to
+`commonjs` only for testing. The workaround is to set the environment variable `TS_NODE_COMPILER_OPTIONS` when executing
+`mocha` to give `ts-node` a module setting of `commonjs`. For example, in `package.json`:
 
 ```
   "scripts": {

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -9,3 +9,36 @@ Tests here are kept next to their code (not in a separate dir). This was done to
 - `npm run compile` - compile the ES6 Typescript into the `/lib` directory
 - `npm run lint` - run the Typescript linter using the `tslint.json` config file.
 - `npm test` - run the tests using the local `.mocharc.json` config file. As the config includes the Typescript transpilation hook `ts-node/register` it does not require pre-compilation before running.
+
+## ES Modules
+
+If your typescript project's `tsconfig.json` has module code generation set to something other than `CommonJS`, you may
+encounter an error "SyntaxError: Unexpected token {" when you use an import statement.
+
+```
+import { fail, ok } from 'assert';
+       ^
+
+SyntaxError: Unexpected token {
+    at Module._compile (internal/modules/cjs/loader.js:721:23)
+
+```
+
+This is because the underlying ts-node does not support ES modules:
+
+
+ > Import Statements
+ > Current node.js stable releases do not support ES modules. Additionally, ts-node does not have the required hooks into node.js to support ES modules. You will need to set "module": "commonjs" in your tsconfig.json for your code to work.
+
+See: https://www.npmjs.com/package/ts-node#import-statements
+
+A workaround is to change the `compilerOptions` that `ts-node` sees when `mocha` is executed. The environment variable
+`TS_NODE_COMPILER_OPTIONS` can be set when executing `mocha` to give `ts-code` a module setting of `commonjs`. In `package.json`:
+
+```
+  "scripts": {
+    "test": "env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' mocha"
+  }
+```
+
+


### PR DESCRIPTION
When building a typescript project with typescript compiler options for `module` set to anything except `commonjs`, mocha tests will fail when you attempt to do an `import` in your code. Figuring out why was non-trivial, and probably worthy of a note here in the README to forewarn people who end up on this path, and provide a workaround.

More discussion on the underlying issue of ts-node (and node) not supporting ES modules is found here:
  - https://github.com/TypeStrong/ts-node/issues/212
  - https://github.com/TypeStrong/ts-node/issues/182

