### PR TITLE
add npm script to remove all node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "postinstall": "lerna bootstrap",
-    "test": "lerna run --stream test"
+    "test": "lerna run --stream test",
+    "clean": "lerna clean"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
For cleaning up all dependencies and reinstalling them, add `lerna clean` as a npm script.