### PR TITLE
Remove CI-SKIP on GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
           - 10
           - 12
           - 14
+          - 16
     steps:
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         node:
-          - 10
           - 12
           - 14
           - 16

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,35 +8,8 @@ name: Tests
       - reopened
 
 jobs:
-  prepare-commit-msg:
-    name: Retrive head commit message
-    runs-on: ubuntu-latest
-    outputs:
-      HEAD_COMMIT_MSG: '${{ steps.commitMsg.outputs.HEAD_COMMIT_MSG }}'
-    steps:
-      - uses: actions/checkout@v2
-        if: github.event_name == 'pull_request'
-      - name: find commit msg for PR
-        id: commitMsg
-        if: github.event_name == 'pull_request'
-        run: >-
-          echo "::set-output name=HEAD_COMMIT_MSG::$(git log --no-merges -1
-          --oneline)"
-
-  check-skip:
-    name: Check to skip CI
-    needs: prepare-commit-msg
-    runs-on: ubuntu-latest
-    if: >-
-      ${{ !contains(github.event.head_commit.message, '[ci skip]') &&
-      !contains(needs.prepare-commit-msg.outputs.HEAD_COMMIT_MSG, '[ci skip]')
-      }}
-    steps:
-      - run: 'echo "${{ github.event.head_commit.message }}"'
-
   test:
     name: 'Node.js v${{ matrix.node }}'
-    needs: check-skip
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
[GitHub now support it](https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/).