### PR TITLE
Update chromedriver, selenium-webdriver

### DIFF
--- a/packages/selenium/package.json
+++ b/packages/selenium/package.json
@@ -14,9 +14,9 @@
     "@babel/polyfill": "^7.4.0",
     "@babel/preset-env": "^7.3.4",
     "@babel/register": "^7.0.0",
-    "chromedriver": "^93.0.1",
+    "chromedriver": "^100.0.0",
     "mocha": "latest",
-    "selenium-webdriver": "^4.0.0-rc-1"
+    "selenium-webdriver": "^4.1.1"
   },
   "engines": {
     "node": ">=10.0.0"


### PR DESCRIPTION
Fix `This version of ChromeDriver only supports Chrome version 93` error because `Current browser version is 100.0.4896.75 with binary path /usr/bin/google-chrome`.

And use stable `selenium-webdriver` version.