### PR TITLE
match node version and run tests periodically

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
     strategy:
       matrix:
         node:
-          - 12
           - 14
           - 16
+          - 17
     steps:
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ name: Tests
       - opened
       - synchronize
       - reopened
+  schedule:
+    - cron: '0 6 * * 0'
 
 jobs:
   test:


### PR DESCRIPTION
* Match node versions with mocha repository 
* Run test every week because this repository is not actively changed, so sometimes we didn't realize tests are broken.