### PR TITLE
Disable tests with Node 18 temporarily

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         node:
           - 14
           - 16
-          - 18
+#          - 18
     steps:
       - uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
Because `selenium-webdriver` has a bug with Node 18, Node 18 in our CI tests will be disabled until `selenium-webdriver`'s new release include [the fix](https://github.com/SeleniumHQ/selenium/pull/10611).

