### PR TITLE
puppeteer: fix deprecated waitFor

### DIFF
--- a/packages/puppeteer/test/index.spec.js
+++ b/packages/puppeteer/test/index.spec.js
@@ -28,7 +28,7 @@ describe('my app', function() {
 
   it('h1 should say "mocha is good"', async function() {  
     const tag = 'h1'; 
-    await page.waitFor(tag); 
+    await page.waitForSelector(tag);
     const heading = await page.$eval(tag, heading => heading.innerText);
     assert.equal(heading, 'Mocha is good') 
   }); 


### PR DESCRIPTION
> waitFor is deprecated and will be removed in a future release. See https://github.com/puppeteer/puppeteer/issues/6214 for details and how to migrate your code.

Fix a deprecated warning.
