### PR TITLE
deps: update lerna to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/mochajs/mocha-examples#readme",
   "devDependencies": {
-    "lerna": "^4.0.0",
-    "rimraf": "^2.7.1"
+    "lerna": "^5.0.0",
+    "rimraf": "^3.0.2"
   }
 }


### PR DESCRIPTION
Lerna is now maintained by Nwrl. So, we should use [v5](https://github.com/lerna/lerna/releases/tag/v5.0.0) even if there is no significant improvement and performance.