### PR TITLE
selenium: update driver to make compatible with node 18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         node:
           - 14
           - 16
-#          - 18
+          - 18
     steps:
       - uses: actions/setup-node@v1
         with:

--- a/packages/selenium/package.json
+++ b/packages/selenium/package.json
@@ -16,7 +16,7 @@
     "@babel/register": "^7.0.0",
     "chromedriver": "latest",
     "mocha": "latest",
-    "selenium-webdriver": "^4.1.1"
+    "selenium-webdriver": "^4.2.0"
   },
   "engines": {
     "node": ">=10.0.0"


### PR DESCRIPTION
In #52 selenium-driver was not compatible with Node 18.
This bug was fixed in https://github.com/SeleniumHQ/selenium/pull/10611 and included in [selenium-driver 4.2.0](https://github.com/SeleniumHQ/selenium/releases/tag/selenium-4.2.0).