### PR TITLE
Force to use latest npm dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,5 +33,7 @@ jobs:
             ${{ runner.os }}-node-v${{ matrix.node }}-
       - name: Install Dependencies
         run: npm install
+      - name: Update Dependencies
+        run: npm run update
       - name: Run All Node.js Tests
         run: npm run test

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "postinstall": "lerna bootstrap --no-ci && npm run clean:packagelock",
+    "update": "lerna exec npm update",
     "test": "lerna run --stream test",
     "clean": "lerna clean",
     "postclean": "npm run clean:packagelock",


### PR DESCRIPTION
Even if we set the dependency versions to the latest, `npm install` is not enough because of caches.
It occurs ci failed whenever the new chromdriver version is released.
So, `npm update` will force us to update them if there is a new version.