### PR TITLE
Set chromedriver version to 104

### DIFF
--- a/packages/selenium/package.json
+++ b/packages/selenium/package.json
@@ -14,7 +14,7 @@
     "@babel/polyfill": "^7.4.0",
     "@babel/preset-env": "^7.3.4",
     "@babel/register": "^7.0.0",
-    "chromedriver": "latest",
+    "chromedriver": "^104.0.0",
     "mocha": "latest",
     "selenium-webdriver": "^4.2.0"
   },


### PR DESCRIPTION
GH Actions user 104.0.5, but chromedriver has been updated to 105.0.0.

```
example-selenium-app:        "before each" hook for "should render a message on a Google search result":
example-selenium-app:      SessionNotCreatedError: session not created: This version of ChromeDriver only supports Chrome version 105
example-selenium-app: Current browser version is 104.0.5[112](https://github.com/mochajs/mocha-examples/runs/8207049839?check_suite_focus=true#step:7:113).101 with binary path /usr/bin/google-chrome
example-selenium-app:       at Object.throwDecodedError (node_modules/selenium-webdriver/lib/error.js:522:15)
example-selenium-app:       at parseHttpResponse (node_modules/selenium-webdriver/lib/http.js:589:13)
example-selenium-app:       at Executor.execute (node_modules/selenium-webdriver/lib/http.js:514:28)
example-selenium-app:       at processTicksAndRejections (node:internal/process/task_queues:96:5)
```