### PR TITLE
chore: bump CI Node versions to 18, 20, and 22 (LTS)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ jobs:
     strategy:
       matrix:
         node:
-          - 14
-          - 16
           - 18
+          - 20
+          - 22
     steps:
       - uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
Fixes #94.