### PR TITLE
feat: added global-fixture example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Additional examples include:
 - [Babel application](packages/babel/)
 - [Browser](packages/browser/)
 - [Express REST API](packages/express-rest-api/)
+- [Global Fixture](packages/global-fixture/)
 - [Karma](packages/karma/)
 - [Node Sqlite 3 example](packages/node-sqlite3/)
 - [Playwright application](packages/playwright/)

--- a/packages/global-fixture/README.md
+++ b/packages/global-fixture/README.md
@@ -1,0 +1,6 @@
+# Global Fixture Example
+
+A straightforward example of using Mocha with a global setup and teardown fixture.
+
+1. `npm install`
+2. `npm run test`

--- a/packages/global-fixture/fixture.js
+++ b/packages/global-fixture/fixture.js
@@ -1,0 +1,30 @@
+class Server {
+  #count = 0;
+
+  #timer = setInterval(() => {
+    this.#tick();
+  }, 100);
+
+  constructor() {
+    this.#tick();
+  }
+
+  #tick() {
+    globalThis.fixtureCount = this.#count += 1;
+  }
+
+  teardown() {
+    clearInterval(this.#timer);
+  }
+}
+
+let server;
+
+exports.mochaGlobalSetup = () => {
+  server = new Server();
+};
+
+exports.mochaGlobalTeardown = () => {
+  server.teardown();
+  server = undefined;
+};

--- a/packages/global-fixture/package.json
+++ b/packages/global-fixture/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "global-fixture",
+  "version": "1.0.0",
+  "description": "Global fixture example",
+  "scripts": {
+    "test": "mocha test.spec.js --require fixture.js"
+  },
+  "engines": {
+    "node": ">=10.0.0"
+  },
+  "license": "ISC",
+  "devDependencies": {
+    "mocha": "latest"
+  }
+}

--- a/packages/global-fixture/test.spec.js
+++ b/packages/global-fixture/test.spec.js
@@ -1,0 +1,7 @@
+describe("example", () => {
+  it("reads from the global count", () => {
+    if (typeof globalThis.fixtureCount !== "number") {
+      throw new Error("Expected a globalThis.fixtureCount.");
+    }
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #100
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a fixture that exercises both _setup_ and _teardown_, as an example.